### PR TITLE
Add ability to set custom element for notification preferences

### DIFF
--- a/src/components/FloatingNotificationInbox/FloatingNotificationInbox.tsx
+++ b/src/components/FloatingNotificationInbox/FloatingNotificationInbox.tsx
@@ -18,6 +18,8 @@ export interface Props extends NotificationInboxProps {
   hideArrow?: boolean;
   NotificationItem?: NotificationListItem;
   layout?: string[];
+  hideNotificationPreferences?: boolean;
+  customNotificationPreferences?: React.ReactElement | React.ReactElement[];
 }
 
 /**

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -9,6 +9,11 @@ import FooterLogo from './FooterLogo';
 import SettingsIcon from './SettingsIcon';
 import StyledFooter from './StyledFooter';
 
+export interface FooterProps {
+  hideNotificationPreferences?: boolean;
+  customNotificationPreferences?: React.ReactElement | React.ReactElement[];
+}
+
 /**
  * Footer for the notification inbox. Renders a button to toggle the user
  * preferences panel.
@@ -16,15 +21,16 @@ import StyledFooter from './StyledFooter';
  * @example
  * <Footer />
  */
-export default function Footer() {
+export default function Footer({
+  hideNotificationPreferences = false,
+  customNotificationPreferences,
+}: FooterProps) {
   const [showPreferences, togglePreferences] = useToggle(false);
   const config = useConfig();
   const { inbox } = config;
-  const preferencesEnabled = pathOr(
-    true,
-    ['features', 'notificationPreferences', 'enabled'],
-    inbox,
-  );
+  const preferencesEnabled = hideNotificationPreferences
+    ? false
+    : pathOr(true, ['features', 'notificationPreferences', 'enabled'], inbox);
 
   const theme = useTheme();
   const { footer: footerTheme } = theme;
@@ -46,7 +52,14 @@ export default function Footer() {
     }
   `;
 
-  if (showPreferences) return <UserPreferencesPanel onClose={togglePreferences} />;
+  if (showPreferences) {
+    return (
+      <UserPreferencesPanel
+        onClose={togglePreferences}
+        customNotificationPreferences={customNotificationPreferences}
+      />
+    );
+  }
 
   return (
     <StyledFooter>

--- a/src/components/NotificationInbox/NotificationInbox.tsx
+++ b/src/components/NotificationInbox/NotificationInbox.tsx
@@ -16,6 +16,8 @@ export interface NotificationInboxProps {
   storeId?: string;
   NotificationItem?: NotificationListItem;
   layout?: string[];
+  hideNotificationPreferences?: boolean;
+  customNotificationPreferences?: React.ReactElement | React.ReactElement[];
 }
 
 /**
@@ -34,6 +36,8 @@ export default function NotificationInbox({
   onNotificationClick,
   NotificationItem,
   storeId = 'default',
+  hideNotificationPreferences = false,
+  customNotificationPreferences,
 }: NotificationInboxProps) {
   const store = useNotifications(storeId);
 
@@ -56,7 +60,11 @@ export default function NotificationInbox({
           NotificationItem={NotificationItem}
         />
         <EnablePushNotificationsBanner key="push-notifications-banner" />
-        <Footer key="footer" />
+        <Footer
+          key="footer"
+          hideNotificationPreferences={hideNotificationPreferences}
+          customNotificationPreferences={customNotificationPreferences}
+        />
       </Layout>
     </StyledContainer>
   );

--- a/src/components/UserPreferencesPanel/UserPreferencesPanel.tsx
+++ b/src/components/UserPreferencesPanel/UserPreferencesPanel.tsx
@@ -11,6 +11,7 @@ import PreferencesCategories from './PreferencesCategories';
 
 export interface Props {
   onClose: () => void;
+  customNotificationPreferences?: React.ReactElement | React.ReactElement[];
 }
 
 /**
@@ -19,7 +20,7 @@ export interface Props {
  * @example
  * <UserPreferencesPanel onClose={closePanel} />
  */
-export default function UserPreferencesPanel({ onClose }: Props) {
+export default function UserPreferencesPanel({ onClose, customNotificationPreferences }: Props) {
   const preferences = useNotificationPreferences();
   const theme = useTheme();
   const { footer: footerTheme, header: headerTheme, container: containerTheme } = theme;
@@ -69,7 +70,7 @@ export default function UserPreferencesPanel({ onClose }: Props) {
         </button>
       </StyledHeader>
       <div className="content">
-        <PreferencesCategories />
+        {customNotificationPreferences ? customNotificationPreferences : <PreferencesCategories />}
       </div>
       <StyledFooter>
         <div


### PR DESCRIPTION
For our use case we have a custom react element to handle enabling/disabling specific notification channels. This PR adds support for adding that custom element into the popover. It also allows disabling the notification preferences entirely if you don't need them.