### PR TITLE
feat: add support for custom NotificationBadge

### DIFF
--- a/src/components/Bell/Bell.tsx
+++ b/src/components/Bell/Bell.tsx
@@ -8,7 +8,8 @@ import BellBadge from './BellBadge';
 import BellIcon from './BellIcon';
 
 export interface Props {
-  Icon?: React.ReactElement;
+  Icon?: JSX.Element;
+  NotificationBadge?: (props: { count: number }) => JSX.Element | null;
   onClick: () => void;
   storeId?: string;
   counter?: 'unread' | 'unseen';
@@ -23,7 +24,13 @@ export interface Props {
  * @example
  * <Bell onClick={toggleNotifications} />
  */
-export default function Bell({ Icon, onClick, storeId, counter }: Props) {
+export default function Bell({
+  Icon,
+  NotificationBadge = BellBadge,
+  onClick,
+  storeId,
+  counter,
+}: Props) {
   const notifications = useBell({ storeId });
   const theme = useTheme();
   const { icon: iconTheme } = theme;
@@ -59,8 +66,8 @@ export default function Bell({ Icon, onClick, storeId, counter }: Props) {
     >
       <div css={iconStyle}>{!isNil(Icon) ? Icon : <BellIcon />}</div>
       {notifications && (
-        <BellBadge
-          counter={counter === 'unread' ? notifications?.unreadCount : notifications?.unseenCount}
+        <NotificationBadge
+          count={counter === 'unread' ? notifications?.unreadCount : notifications?.unseenCount}
         />
       )}
     </a>

--- a/src/components/Bell/Bell.tsx
+++ b/src/components/Bell/Bell.tsx
@@ -9,7 +9,7 @@ import BellIcon from './BellIcon';
 
 export interface Props {
   Icon?: JSX.Element;
-  NotificationBadge?: (props: { count: number }) => JSX.Element | null;
+  Badge?: (props: { count: number }) => JSX.Element | null;
   onClick: () => void;
   storeId?: string;
   counter?: 'unread' | 'unseen';
@@ -24,13 +24,7 @@ export interface Props {
  * @example
  * <Bell onClick={toggleNotifications} />
  */
-export default function Bell({
-  Icon,
-  NotificationBadge = BellBadge,
-  onClick,
-  storeId,
-  counter,
-}: Props) {
+export default function Bell({ Icon, Badge = BellBadge, onClick, storeId, counter }: Props) {
   const notifications = useBell({ storeId });
   const theme = useTheme();
   const { icon: iconTheme } = theme;
@@ -66,7 +60,7 @@ export default function Bell({
     >
       <div css={iconStyle}>{!isNil(Icon) ? Icon : <BellIcon />}</div>
       {notifications && (
-        <NotificationBadge
+        <Badge
           count={counter === 'unread' ? notifications?.unreadCount : notifications?.unseenCount}
         />
       )}

--- a/src/components/Bell/BellBadge.tsx
+++ b/src/components/Bell/BellBadge.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '../../context/MagicBellThemeContext';
 import Badge from '../Badge';
 
 export interface Props {
-  counter: number;
+  count: number;
 }
 
 /**
@@ -14,13 +14,14 @@ export interface Props {
  * It must be wrapped in a {@link MagicBellThemeProvider}.
  *
  * @example
- * <BellBadge store={notifications} displayCounterUnread />
+ * <BellBadge count={3} />
  */
-export default function BellBadge({ counter }: Props) {
+export default function BellBadge({ count }: Props) {
   const theme = useTheme();
   const { icon: iconTheme } = theme;
 
-  if (counter === 0) return null;
+  if (count === 0) return null;
+
   return (
     <div
       css={css`
@@ -30,7 +31,7 @@ export default function BellBadge({ counter }: Props) {
         left: 80%;
       `}
     >
-      <Badge count={counter} />
+      <Badge count={count} />
     </div>
   );
 }

--- a/src/components/MagicBell/MagicBell.tsx
+++ b/src/components/MagicBell/MagicBell.tsx
@@ -27,6 +27,7 @@ export interface Props {
   }) => JSX.Element;
   theme?: DeepPartial<IMagicBellTheme>;
   BellIcon?: JSX.Element;
+  NotificationBadge?: (props: { count: number }) => JSX.Element;
   defaultIsOpen?: boolean;
   stores?: StoreConfig[];
   locale?: string | CustomLocale;
@@ -49,6 +50,7 @@ export interface Props {
  * @param props.userKey Computed HMAC of the user whose notifications will be displayed, compute this with the secret of the magicbell project
  * @param props.theme Object to customize the theme
  * @param props.BellIcon Icon for the bell
+ * @param props.NotificationBadge A custom badge component to show the number of unread or unseen notifications
  * @param props.defaultIsOpen Show the children when the component is rendered. It is false by default.
  * @param props.stores Configuration of stores to be created
  * @param props.locale Locale to use in the components
@@ -68,6 +70,7 @@ export interface Props {
 export default function MagicBell({
   children,
   BellIcon,
+  NotificationBadge,
   defaultIsOpen = false,
   onNewNotification,
   onToggle,
@@ -92,7 +95,12 @@ export default function MagicBell({
     <MagicBellChildrenWrapper {...settings}>
       <div>
         <div ref={launcherRef} aria-expanded={isOpen}>
-          <Bell onClick={handleToggle} Icon={BellIcon} counter={bellCounter} />
+          <Bell
+            onClick={handleToggle}
+            Icon={BellIcon}
+            NotificationBadge={NotificationBadge}
+            counter={bellCounter}
+          />
         </div>
         {isOpen && children({ isOpen, toggle: handleToggle, launcherRef })}
       </div>

--- a/src/components/MagicBell/MagicBell.tsx
+++ b/src/components/MagicBell/MagicBell.tsx
@@ -27,7 +27,7 @@ export interface Props {
   }) => JSX.Element;
   theme?: DeepPartial<IMagicBellTheme>;
   BellIcon?: JSX.Element;
-  NotificationBadge?: (props: { count: number }) => JSX.Element;
+  Badge?: (props: { count: number }) => JSX.Element;
   defaultIsOpen?: boolean;
   stores?: StoreConfig[];
   locale?: string | CustomLocale;
@@ -50,7 +50,7 @@ export interface Props {
  * @param props.userKey Computed HMAC of the user whose notifications will be displayed, compute this with the secret of the magicbell project
  * @param props.theme Object to customize the theme
  * @param props.BellIcon Icon for the bell
- * @param props.NotificationBadge A custom badge component to show the number of unread or unseen notifications
+ * @param props.Badge A custom badge component to show the number of unread or unseen notifications
  * @param props.defaultIsOpen Show the children when the component is rendered. It is false by default.
  * @param props.stores Configuration of stores to be created
  * @param props.locale Locale to use in the components
@@ -70,7 +70,7 @@ export interface Props {
 export default function MagicBell({
   children,
   BellIcon,
-  NotificationBadge,
+  Badge,
   defaultIsOpen = false,
   onNewNotification,
   onToggle,
@@ -95,12 +95,7 @@ export default function MagicBell({
     <MagicBellChildrenWrapper {...settings}>
       <div>
         <div ref={launcherRef} aria-expanded={isOpen}>
-          <Bell
-            onClick={handleToggle}
-            Icon={BellIcon}
-            NotificationBadge={NotificationBadge}
-            counter={bellCounter}
-          />
+          <Bell onClick={handleToggle} Icon={BellIcon} Badge={Badge} counter={bellCounter} />
         </div>
         {isOpen && children({ isOpen, toggle: handleToggle, launcherRef })}
       </div>

--- a/stories/MagicBell.stories.tsx
+++ b/stories/MagicBell.stories.tsx
@@ -100,11 +100,11 @@ WithUnreadCount.args = {
   bellCounter: 'unread',
 };
 
-export const WithCustomNotificationBadge = Template.bind({});
-WithCustomNotificationBadge.args = {
+export const WithCustomBadge = Template.bind({});
+WithCustomBadge.args = {
   ...Default.args,
   bellCounter: 'unread',
-  NotificationBadge: ({ count }) => (
+  Badge: ({ count }) => (
     <div
       style={{
         position: 'absolute',

--- a/stories/MagicBell.stories.tsx
+++ b/stories/MagicBell.stories.tsx
@@ -99,3 +99,28 @@ WithUnreadCount.args = {
   userKey: 'pvorWv0ff2MvYFNyadwOLmFzTZnT1LCFxzTELAULYT4=',
   bellCounter: 'unread',
 };
+
+export const WithCustomNotificationBadge = Template.bind({});
+WithCustomNotificationBadge.args = {
+  ...Default.args,
+  bellCounter: 'unread',
+  NotificationBadge: ({ count }) => (
+    <div
+      style={{
+        position: 'absolute',
+        background: '#5225c1',
+        color: 'white',
+        textAlign: 'center',
+        fontSize: 12,
+        top: -4,
+        right: -2,
+        width: 16,
+        height: 16,
+        padding: 2,
+        borderRadius: 8,
+      }}
+    >
+      {count}
+    </div>
+  ),
+};

--- a/tests/src/components/MagicBell/MagicBell.spec.tsx
+++ b/tests/src/components/MagicBell/MagicBell.spec.tsx
@@ -215,7 +215,7 @@ test('calls the onNewNotification callback when a new notification is received',
   expect(onNewNotification).toHaveBeenCalledWith(notification);
 });
 
-test('supports a custom NotificationBadge', async () => {
+test('supports a custom notification Badge', async () => {
   const Badge = ({ count }) => <div data-testid="custom-badge">{count}</div>;
 
   render(
@@ -223,7 +223,7 @@ test('supports a custom NotificationBadge', async () => {
       apiKey={apiKey}
       userEmail={userEmail}
       userKey={userKey}
-      NotificationBadge={Badge}
+      Badge={Badge}
       bellCounter="unread"
     >
       {() => <div data-testid="children" />}

--- a/tests/src/components/MagicBell/MagicBell.spec.tsx
+++ b/tests/src/components/MagicBell/MagicBell.spec.tsx
@@ -214,3 +214,22 @@ test('calls the onNewNotification callback when a new notification is received',
   expect(onNewNotification).toHaveBeenCalledTimes(1);
   expect(onNewNotification).toHaveBeenCalledWith(notification);
 });
+
+test('supports a custom NotificationBadge', async () => {
+  const Badge = ({ count }) => <div data-testid="custom-badge">{count}</div>;
+
+  render(
+    <MagicBell
+      apiKey={apiKey}
+      userEmail={userEmail}
+      userKey={userKey}
+      NotificationBadge={Badge}
+      bellCounter="unread"
+    >
+      {() => <div data-testid="children" />}
+    </MagicBell>,
+  );
+
+  const badge = screen.getByTestId('custom-badge');
+  await waitFor(() => expect(badge).toHaveTextContent('4'));
+});


### PR DESCRIPTION
This pull request adds support for a custom notification badge. 

Note that part of this feature is that all the styling for the custom badge is to be added by the custom implementation. That includes the positioning and handling if a `0` value should be rendered or not.

**Example**

```jsx
const badgeStyle = { position: "absolute", top: -4, right: -2, /* … */ };

function NotificationBadge({ count }: { count: number }) {
  if (count === 0) return null;

  return <div style={badgeStyle}>{count}</div>;
}

function MyPage() {
  return (
    <MagicBell NotificationBadge={NotificationBadge} userKey={userKey}>
      {(props) => <Inbox {...props} />}
    </MagicBell>
  );
}
```