### PR TITLE
test: wrap state updates in act

### DIFF
--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,3 +1,18 @@
 import '@testing-library/jest-dom/extend-expect';
 
+const _consoleError = console.error.bind(console);
+console.error = (message, ...args) => {
+  // Tests having act errors can be flacky, let's prevent flacky tests by making them fail
+  if (/test was not wrapped in act/i.test(message)) {
+    throw new Error(message);
+  }
+
+  // another flacky test that should just bubble up
+  if (/Cannot update a component .* while rendering a different component/) {
+    throw new Error(message);
+  }
+
+  _consoleError(message, ...args);
+};
+
 global.open = jest.fn();

--- a/tests/src/components/Bell/Bell.spec.tsx
+++ b/tests/src/components/Bell/Bell.spec.tsx
@@ -4,7 +4,7 @@ import {
   useNotification,
   useNotificationStoresCollection,
 } from '@magicbell/react-headless';
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import userEvent from '@testing-library/user-event';
 import { Response, Server } from 'miragejs';
@@ -51,28 +51,28 @@ test('does not render the notification count if there are no notifications', () 
   expect(screen.queryByRole('status', { name: /1 unread items/i })).not.toBeInTheDocument();
 });
 
-test('renders the number of notifications if there are some', async() => {
+test('renders the number of notifications if there are some', async () => {
   render(<Bell onClick={jest.fn()} />);
 
-  useNotificationStoresCollection.setState({
-    stores: { default: buildStore({ unseenCount: 1 }) },
+  act(() => {
+    useNotificationStoresCollection.setState({
+      stores: { default: buildStore({ unseenCount: 1 }) },
+    });
   });
 
-  await waitFor(() => {
-    screen.getByRole('status', { name: /1 unread items/i });
-  });
+  await waitFor(() => screen.getByRole('status', { name: /1 unread items/i }));
 });
 
 test('shows the number of unread notifications if counter is set to unread', async () => {
   render(<Bell onClick={jest.fn()} counter="unread" />);
 
-  useNotificationStoresCollection.setState({
-    stores: { default: buildStore({ unreadCount: 2 }) },
+  act(() => {
+    useNotificationStoresCollection.setState({
+      stores: { default: buildStore({ unreadCount: 2 }) },
+    });
   });
 
-  await waitFor(() => {
-    screen.getByRole('status', { name: /2 unread items/i });
-  });
+  await waitFor(() => screen.getByRole('status', { name: /2 unread items/i }));
 });
 
 test('can render the bell icon with the custom color and size', () => {

--- a/tests/src/components/FloatingNotificationInbox/FloatingNotificationInbox.spec.tsx
+++ b/tests/src/components/FloatingNotificationInbox/FloatingNotificationInbox.spec.tsx
@@ -1,5 +1,5 @@
 import { useConfig } from '@magicbell/react-headless';
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { Response, createServer } from 'miragejs';
@@ -20,7 +20,9 @@ const stores = [
 let server;
 
 beforeEach(async () => {
-  useConfig.setState({ ...sampleConfig, lastFetchedAt: Date.now() });
+  act(() => {
+    useConfig.setState({ ...sampleConfig, lastFetchedAt: Date.now() });
+  });
 
   server = createServer({
     environment: 'test',


### PR DESCRIPTION
Wrapping these state updates in `act` to fix the `test was not wrapped in act` error.

I've also wrapped `console.error` in our tests so that it will throw an error whenever this error is being printed to the terminal. I think it's a bad error to have in our tests. So we might just as well make those tests fail.