### PR TITLE
fix: restrict timeAgo to nodes in local scope

### DIFF
--- a/src/components/NotificationContent/NotificationContent.tsx
+++ b/src/components/NotificationContent/NotificationContent.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { css, jsx } from '@emotion/react';
 import INotification from '@magicbell/react-headless/dist/types/INotification';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { cancel, render } from 'timeago.js';
 
 export interface Props {
@@ -17,10 +17,12 @@ export interface Props {
  */
 export default function NotificationContent({ notification }: Props) {
   const { sanitizedContent: markup } = notification;
+  const ref = useRef<HTMLElement>(null);
 
   // TODO: Move this to a plugin framework
   useEffect(() => {
-    const nodes = document.querySelectorAll('time[datetime]');
+    if (!ref.current) return;
+    const nodes = ref.current.querySelectorAll('time[datetime]');
     if (nodes.length > 0) render(nodes);
 
     return () => {
@@ -31,6 +33,7 @@ export default function NotificationContent({ notification }: Props) {
   if (!markup || markup.replace(/(\n|\s|\r)/gi, '') === '') return null;
   return (
     <article
+      ref={ref}
       css={css`
         color: inherit !important;
         cursor: inherit;

--- a/tests/src/components/NotificationContent/NotificationContent.spec.tsx
+++ b/tests/src/components/NotificationContent/NotificationContent.spec.tsx
@@ -80,3 +80,19 @@ test('does not replace time elements in upper scopes', async () => {
   expect(inScope).toHaveAttribute('timeago-id');
   expect(outOfScope).not.toHaveAttribute('timeago-id');
 });
+
+test('time elements without dateTime attribute are ignored by timeAgo', async () => {
+  jest.setSystemTime(1615460277120);
+
+  const { result } = renderHook(() =>
+    useNotificationFactory({
+      ...sampleNotification,
+      content: '<p>The event starts <time data-testid="in-scope">on March 10</time>.</p>',
+    }),
+  );
+
+  render(<NotificationContent notification={result.current} />);
+
+  const time = screen.getByTestId('in-scope');
+  expect(time).not.toHaveAttribute('timeago-id');
+});

--- a/tests/src/components/NotificationContent/NotificationContent.spec.tsx
+++ b/tests/src/components/NotificationContent/NotificationContent.spec.tsx
@@ -1,5 +1,5 @@
 import { useNotificationFactory } from '@magicbell/react-headless';
-import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 import { NotificationContent } from '../../../../src';
@@ -34,20 +34,49 @@ test('renders the content as returned from the API, without sanitizing', () => {
   screen.getByRole('img');
 });
 
-// This one doesn't work, the behavior is covered by other tests, but in this specific one, the
-// datetime is never replaced
-test.skip('replaces the content of time tags with a relative datetime', async () => {
+test('replaces the content of time elements with a relative datetime', async () => {
   jest.setSystemTime(1615373877120);
 
   const { result } = renderHook(() =>
     useNotificationFactory({
       ...sampleNotification,
-      content: '<p>The event starts <time datetime="2021-03-11T05:33:12Z">on March 11</time>.</p>',
+      content:
+        '<p>The event starts <time datetime="2021-03-11T05:33:12Z" data-testid="time">on March 11</time>.</p>',
     }),
   );
 
   render(<NotificationContent notification={result.current} />);
-  screen.getByText(/on March 11/i);
 
-  await waitForElementToBeRemoved(() => screen.getByText(/on March 11/i));
+  // Ideally, we would be checking by display value, but for some reason the textContent is not
+  // updated in this test. However, we can still verify that timeAgo does its thing, by checking for
+  // the timeago-id attribute.
+  const time = screen.getByTestId('time');
+  expect(time).toHaveAttribute('timeago-id');
+});
+
+test('does not replace time elements in upper scopes', async () => {
+  jest.setSystemTime(1615460277120);
+
+  const { result } = renderHook(() =>
+    useNotificationFactory({
+      ...sampleNotification,
+      content:
+        '<p>The event starts <time datetime="" data-testid="in-scope">on March 10</time>.</p>',
+    }),
+  );
+
+  render(
+    <div>
+      <time dateTime="" data-testid="out-of-scope">
+        on March 10
+      </time>
+      <NotificationContent notification={result.current} />
+    </div>,
+  );
+
+  const inScope = screen.getByTestId('in-scope');
+  const outOfScope = screen.getByTestId('out-of-scope');
+
+  expect(inScope).toHaveAttribute('timeago-id');
+  expect(outOfScope).not.toHaveAttribute('timeago-id');
 });


### PR DESCRIPTION
The inbox replaces `<time>` elements with absolute date formats to a relative format. This operation was also applied to all `<time>` elements outside of the inbox.

This change restricts the replacement of `<time>` elements to the inbox (`NotificationItem` really) itself. 

![dayjs-leak](https://user-images.githubusercontent.com/1196524/146964832-890d9aee-ded7-4de0-8471-ecaf96b9b778.gif)
