### PR TITLE
fix: reattach inbox height observer on ref change

### DIFF
--- a/src/components/NotificationInbox/NotificationInboxContent.tsx
+++ b/src/components/NotificationInbox/NotificationInboxContent.tsx
@@ -2,7 +2,7 @@
 import { jsx } from '@emotion/react';
 import { NotificationStore } from '@magicbell/react-headless/dist/hooks/useNotifications';
 import INotification from '@magicbell/react-headless/dist/types/INotification';
-import { useRef } from 'react';
+import { useState } from 'react';
 
 import { useHeight } from '../../lib/window';
 import NotificationList from '../NotificationList';
@@ -32,14 +32,15 @@ export default function NotificationInboxContent({
   height,
   NotificationItem,
 }: NotificationInboxContentProps) {
-  const contentRef = useRef<HTMLDivElement>(null);
+  // we use a refSetter so that the height observer is reattached on a ref change
+  const [contentRef, setContentRef] = useState<HTMLDivElement | null>(null);
   const contentHeight = useHeight(contentRef, height);
 
   if (!store.lastFetchedAt) return null;
   if (store.isEmpty) return <ClearInboxMessage />;
 
   return (
-    <div ref={contentRef} css={{ width: '100%', height: height ?? '100%' }}>
+    <div ref={setContentRef} css={{ width: '100%', height: height ?? '100%' }}>
       <NotificationList
         height={contentHeight}
         notifications={store}

--- a/src/lib/window.ts
+++ b/src/lib/window.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-globals */
-import { useEffect, useRef, useState } from 'react';
+import { MutableRefObject, useEffect, useState } from 'react';
 import ResizeObserver from 'resize-observer-polyfill';
 
 /**
@@ -16,26 +16,25 @@ export function openWindow(url: string) {
 /**
  * Custom hook to observe the height of an HTML element.
  *
- * @param ref
- * @param initialHeight
+ * @param ref - the element to observe, either a ref object or html element
+ * @param initialHeight - optional initial height
  */
-export function useHeight(ref, initialHeight) {
+export function useHeight(ref: MutableRefObject<Element> | Element | null, initialHeight?: number) {
   const [height, setHeight] = useState(initialHeight);
-  const resizeObserverRef = useRef() as any;
 
   useEffect(() => {
-    resizeObserverRef.current = new ResizeObserver((entries: any = []) => {
-      entries.forEach((entry) => {
-        setHeight(entry.contentRect.height);
-      });
+    if (!ref) return;
+
+    const target = ref instanceof Element ? ref : ref.current;
+    if (!target) return;
+
+    const observer = new ResizeObserver(([entry]) => {
+      setHeight(entry.contentRect.height);
     });
 
-    if (ref.current) resizeObserverRef.current.observe(ref.current);
-
-    return () => {
-      if (resizeObserverRef.current) resizeObserverRef.current.disconnect();
-    };
-  }, [ref]);
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [ref, setHeight]);
 
   return height;
 }


### PR DESCRIPTION
On slow internet connections, the inbox height observer could be initialized before the notification list element was added to the DOM. Once the list element was added to the observer was not reattached.

This pull changes the height observer in a way that it now accepts a mutable ref object, as well as an element instance as an argument. The latter allows us to use a ref setter instead of a mutable ref object so that the observer can be initialized _after_ first render.

This fixes the race condition between computing "content height" and fetching notifications.