### PR TITLE
feat: add magicbell-bell data attribute to Bell

### DIFF
--- a/src/components/Bell/Bell.tsx
+++ b/src/components/Bell/Bell.tsx
@@ -58,6 +58,8 @@ export default function Bell({ Icon, Badge = BellBadge, onClick, storeId, counte
       onClick={handleClick}
       css={[cleanslate, containerStyle]}
       aria-label="Notifications"
+      data-testid="bell"
+      data-magicbell-bell
     >
       <div css={iconStyle}>{!isNil(Icon) ? Icon : <BellIcon />}</div>
       {notifications && (

--- a/tests/src/components/Bell/Bell.spec.tsx
+++ b/tests/src/components/Bell/Bell.spec.tsx
@@ -45,6 +45,12 @@ test('renders the notification button', () => {
   screen.getByRole('button', { name: /notifications/i });
 });
 
+test('the notification button has a namespaced data attribute', () => {
+  render(<Bell onClick={jest.fn()} />);
+  const button = screen.getByRole('button', { name: /notifications/i });
+  expect(button).toHaveAttribute('data-magicbell-bell');
+});
+
 test('does not render the notification count if there are no notifications', () => {
   useConfig.setState({ lastFetchedAt: undefined });
 


### PR DESCRIPTION
Some of our users are overriding styles based upon the recently removed `data-testid` attributes. I've added the `data-testid="bell"` attribute back to the `Bell` component to restore the styles for those that have been affected by that change.

As styling based on test ids isn't a long-term solution, I've also added a `data-magicbell-bell` attribute that can serve as a supported root selector, from which we can safely assume that it won't conflict with anything else.

Once this pull is merged, consumers are recommended to migrate from selectors like:

```css
[data-testid="bell"] svg {
  /* custom styles */
}
```

to:

```css
[data-magicbell-bell] svg {
  /* custom styles */
}
```
