### PR TITLE
feat: add support for `EmptyInboxPlaceholder`

### DIFF
--- a/src/components/NotificationInbox/NotificationInbox.tsx
+++ b/src/components/NotificationInbox/NotificationInbox.tsx
@@ -12,6 +12,7 @@ export type NotificationInboxProps = {
   onAllRead?: () => void;
   onNotificationClick?: (notification: INotification) => void;
   storeId?: string;
+  EmptyInboxPlaceholder?: () => React.ReactElement;
   NotificationItem?: NotificationListItem;
   NotificationPreferences?: () => React.ReactElement;
   notificationPreferencesEnabled?: boolean;

--- a/src/components/NotificationInbox/NotificationInboxContent.tsx
+++ b/src/components/NotificationInbox/NotificationInboxContent.tsx
@@ -7,7 +7,6 @@ import { useState } from 'react';
 import { useHeight } from '../../lib/window';
 import NotificationList from '../NotificationList';
 import { NotificationListItem } from '../NotificationList/NotificationList';
-import ClearInboxMessage from './ClearInboxMessage';
 
 export interface NotificationInboxContentProps {
   height?: number;
@@ -35,9 +34,6 @@ export default function NotificationInboxContent({
   // we use a refSetter so that the height observer is reattached on a ref change
   const [contentRef, setContentRef] = useState<HTMLDivElement | null>(null);
   const contentHeight = useHeight(contentRef, height);
-
-  if (!store.lastFetchedAt) return null;
-  if (store.isEmpty) return <ClearInboxMessage />;
 
   return (
     <div ref={setContentRef} css={{ width: '100%', height: height ?? '100%' }}>

--- a/src/components/NotificationInbox/private/NotificationsView.tsx
+++ b/src/components/NotificationInbox/private/NotificationsView.tsx
@@ -12,6 +12,7 @@ import SettingsIcon from '../../Footer/SettingsIcon';
 import Header from '../../Header';
 import { ListItemProps } from '../../NotificationList';
 import Text from '../../Text';
+import ClearInboxMessage from '../ClearInboxMessage';
 import Layout from '../Layout';
 import { NotificationInboxProps, SetViewHandler } from '../NotificationInbox';
 import NotificationInboxContent from '../NotificationInboxContent';
@@ -24,6 +25,7 @@ type NotificationsViewProps = {
   height?: number;
   onAllRead?: () => void;
   NotificationItem?: (props: ListItemProps) => ReactElement;
+  EmptyInboxPlaceholder?: () => ReactElement;
   onNotificationClick?: (notification: INotification) => void;
 };
 
@@ -34,6 +36,7 @@ export default function NotificationsView({
   onAllRead,
   notificationPreferencesEnabled,
   NotificationItem,
+  EmptyInboxPlaceholder = ClearInboxMessage,
   setView,
 }: NotificationsViewProps) {
   const t = useTranslate();
@@ -41,6 +44,7 @@ export default function NotificationsView({
   const store = useNotifications(storeId);
   if (!store) return null;
 
+  const hasNotifications = !store.isEmpty;
   const showPreferencesButton =
     notificationPreferencesEnabled ??
     pathOr(true, ['features', 'notificationPreferences', 'enabled'], config.inbox);
@@ -63,11 +67,15 @@ export default function NotificationsView({
       />
 
       <div key="content" css={{ flex: 1, overflowY: 'hidden' }}>
-        <NotificationInboxContent
-          store={store}
-          onNotificationClick={onNotificationClick}
-          NotificationItem={NotificationItem}
-        />
+        {!store.lastFetchedAt ? null : hasNotifications ? (
+          <NotificationInboxContent
+            store={store}
+            onNotificationClick={onNotificationClick}
+            NotificationItem={NotificationItem}
+          />
+        ) : (
+          <EmptyInboxPlaceholder />
+        )}
       </div>
 
       <EnablePushNotificationsBanner key="push-notifications-banner" />

--- a/tests/factories/NotificationFactory.ts
+++ b/tests/factories/NotificationFactory.ts
@@ -32,3 +32,14 @@ export const sampleNotification = {
   readAt: null,
   archivedAt: null,
 };
+
+export const emptyNotificationPage = {
+  total: 0,
+  current_page: 1,
+  per_page: 15,
+  total_pages: 1,
+  project_id: 7,
+  unseen_count: 0,
+  unread_count: 0,
+  notifications: [],
+};

--- a/tests/src/components/NotificationInbox/NotificationInbox.spec.tsx
+++ b/tests/src/components/NotificationInbox/NotificationInbox.spec.tsx
@@ -12,6 +12,17 @@ import { sampleNotification } from '../../../factories/NotificationFactory';
 
 let server;
 
+const EMPTY_NOTIFICATIONS_PAGE = {
+  total: 0,
+  current_page: 1,
+  per_page: 15,
+  total_pages: 1,
+  project_id: 7,
+  unseen_count: 0,
+  unread_count: 0,
+  notifications: [],
+};
+
 beforeEach(() => {
   useConfig.setState({ ...sampleConfig, lastFetchedAt: Date.now() });
 
@@ -23,11 +34,8 @@ beforeEach(() => {
   });
 
   server.get('/notifications', {
+    ...EMPTY_NOTIFICATIONS_PAGE,
     total: 1,
-    current_page: 1,
-    per_page: 15,
-    total_pages: 1,
-    project_id: 7,
     unseen_count: 1,
     unread_count: 1,
     notifications: [sampleNotification],
@@ -88,21 +96,23 @@ test('clicking the mark-all-read button invokes the onAllRead callback', () => {
 });
 
 test('renders a message and a image if there are no notifications', async () => {
-  server.get('/notifications', {
-    total: 0,
-    current_page: 1,
-    per_page: 15,
-    total_pages: 1,
-    project_id: 7,
-    unseen_count: 0,
-    unread_count: 0,
-    notifications: [],
-  });
+  server.get('/notifications', EMPTY_NOTIFICATIONS_PAGE);
 
   render(<NotificationInbox />);
 
   await waitFor(() => screen.getByText(/We'll let you know when there's more./));
   screen.getByRole('img', { name: /No notifications/ });
+});
+
+test('can render with a custom no-notifications placeholder if there are no notifications', async () => {
+  server.get('/notifications', EMPTY_NOTIFICATIONS_PAGE);
+
+  const EmptyInboxPlaceholder = () => <div data-testid="empty-inbox-placeholder" />;
+  render(<NotificationInbox EmptyInboxPlaceholder={EmptyInboxPlaceholder} />, { locale: 'en' });
+
+  await waitFor(() => screen.findByTestId('empty-inbox-placeholder'));
+  expect(screen.queryByText(/We'll let you know when there's more./)).not.toBeInTheDocument();
+  expect(screen.queryByRole('img', { name: /No notifications/ })).not.toBeInTheDocument();
 });
 
 test('can render the inbox in Spanish', () => {

--- a/tests/src/components/NotificationInbox/NotificationInbox.spec.tsx
+++ b/tests/src/components/NotificationInbox/NotificationInbox.spec.tsx
@@ -8,20 +8,9 @@ import MagicBellProvider from '../../../../src/components/MagicBellProvider';
 import NotificationInbox from '../../../../src/components/NotificationInbox';
 import { renderWithProviders as render } from '../../../__utils__/render';
 import ConfigFactory, { sampleConfig } from '../../../factories/ConfigFactory';
-import { sampleNotification } from '../../../factories/NotificationFactory';
+import { emptyNotificationPage, sampleNotification } from '../../../factories/NotificationFactory';
 
 let server;
-
-const EMPTY_NOTIFICATIONS_PAGE = {
-  total: 0,
-  current_page: 1,
-  per_page: 15,
-  total_pages: 1,
-  project_id: 7,
-  unseen_count: 0,
-  unread_count: 0,
-  notifications: [],
-};
 
 beforeEach(() => {
   useConfig.setState({ ...sampleConfig, lastFetchedAt: Date.now() });
@@ -34,7 +23,7 @@ beforeEach(() => {
   });
 
   server.get('/notifications', {
-    ...EMPTY_NOTIFICATIONS_PAGE,
+    ...emptyNotificationPage,
     total: 1,
     unseen_count: 1,
     unread_count: 1,
@@ -96,7 +85,7 @@ test('clicking the mark-all-read button invokes the onAllRead callback', () => {
 });
 
 test('renders a message and a image if there are no notifications', async () => {
-  server.get('/notifications', EMPTY_NOTIFICATIONS_PAGE);
+  server.get('/notifications', emptyNotificationPage);
 
   render(<NotificationInbox />);
 
@@ -105,7 +94,7 @@ test('renders a message and a image if there are no notifications', async () => 
 });
 
 test('can render with a custom no-notifications placeholder if there are no notifications', async () => {
-  server.get('/notifications', EMPTY_NOTIFICATIONS_PAGE);
+  server.get('/notifications', emptyNotificationPage);
 
   const EmptyInboxPlaceholder = () => <div data-testid="empty-inbox-placeholder" />;
   render(<NotificationInbox EmptyInboxPlaceholder={EmptyInboxPlaceholder} />, { locale: 'en' });


### PR DESCRIPTION
This pull request adds support for a custom "empty inbox placeholder". We already had the option to customize the image, but this allows us to replace the entire view.

A custom placeholder can be provided using the `EmptyInboxPlaceholder` property on the inbox.

```jsx
<MagicBell apiKey={apiKey} userEmail={userEmail}>
  {(props) => (
    <Inbox
      {...props}
      EmptyInboxPlaceholder={() => (
        <div>
          You don't have any notifications yet. 
          Why don't you invite your team members?
        </div>
      )}
    />
  )}
</MagicBell>
```