### PR TITLE
chore: bump @magicbell/react-headless to 2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "microbundle --jsx React.createElement",
     "prepare": "yarn build && husky install",
-    "start": "microbundle watch --jsx React.createElement",
+    "start": "microbundle watch --jsx React.createElement --no-compress",
     "report-coverage": "codecov",
     "test": "TZ=America/New_York jest --collectCoverage --no-cache",
     "test:watch": "TZ=America/New_York jest --watch",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.4.1",
-    "@magicbell/react-headless": "^2.5.0",
+    "@magicbell/react-headless": "^2.5.1",
     "@tippyjs/react": "^4.2.4",
     "ably": "^1.2.14",
     "axios": "^0.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1597,10 +1597,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@magicbell/react-headless@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@magicbell/react-headless/-/react-headless-2.5.0.tgz#132fb384a55919b69215765875d0539e9b42ca50"
-  integrity sha512-aeSxezB05MaAL17ce3embZOOwRMuRwmJDuWdm17xUVp0Qn/nn7CldolsK/i3/PZPwM8E9KmRiRAd5bzZyUcSLg==
+"@magicbell/react-headless@^2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@magicbell/react-headless/-/react-headless-2.5.1.tgz#8df82c485d6e943a9e28be892a76f878ae8c278c"
+  integrity sha512-Q8Ugpp+/+no+sIWe9hoLwx3TAY9PFdP9yX/dEgfu2HU5xZJ8jnq6OtHht3VV0qS5Oo68mUzTpPOBZa6O5cGlaA==
   dependencies:
     ably "^1.2.14"
     axios "^0.24.0"


### PR DESCRIPTION
This update is required so that Network Errors no longer appear as uncaught errors.