### PR TITLE
Expose Preferences component and only show enabled channels

### DIFF
--- a/src/components/UserPreferencesPanel/CategoryPreferences.tsx
+++ b/src/components/UserPreferencesPanel/CategoryPreferences.tsx
@@ -5,6 +5,7 @@ import ToggleInput from './ToggleInput';
 
 interface Props {
   category: string;
+  channels?: string[];
 }
 
 const humanize = (str) =>
@@ -16,7 +17,16 @@ const humanize = (str) =>
     .replace(/(^|\s)\S/g, (letter) => letter.toUpperCase())
     .replace(/(\.|_)/g, ' ');
 
-export default function CategoryPreferences({ category }: Props) {
+function channelToClass(channel: string): string {
+  return {
+    inApp: 'inapp',
+    email: 'email',
+    webPush: 'web-push',
+    mobilePush: 'mobile-push',
+  }[channel] || 'inapp';
+}
+
+export default function CategoryPreferences({ category, channels = ['inApp', 'email', 'webPush'] }: Props) {
   const preferences = useNotificationPreferences();
   const categoryTitle = humanize(category);
 
@@ -27,27 +37,15 @@ export default function CategoryPreferences({ category }: Props) {
   return (
     <>
       <div>{categoryTitle}</div>
-      <div>
-        <ToggleInput
-          id={`${category}-inapp`}
-          value={preferences.categories[category].inApp}
-          onClick={(value) => updatePreferences({ inApp: value })}
-        />
-      </div>
-      <div>
-        <ToggleInput
-          id={`${category}-email`}
-          value={preferences.categories[category].email}
-          onClick={(value) => updatePreferences({ email: value })}
-        />
-      </div>
-      <div>
-        <ToggleInput
-          id={`${category}-web-push`}
-          value={preferences.categories[category].webPush}
-          onClick={(value) => updatePreferences({ webPush: value })}
-        />
-      </div>
+      {channels.map((channel) => (
+        <div key={channel} >
+          <ToggleInput
+            id={`${category}-${channelToClass(channel)}`}
+            value={preferences.categories[category][channel]}
+            onClick={(value) => updatePreferences({ [channel]: value })}
+          />
+        </div>
+      ))}
     </>
   );
 }

--- a/src/components/UserPreferencesPanel/CategoryPreferences.tsx
+++ b/src/components/UserPreferencesPanel/CategoryPreferences.tsx
@@ -5,7 +5,7 @@ import ToggleInput from './ToggleInput';
 
 interface Props {
   category: string;
-  channels?: string[];
+  channels?: Array<'inApp' | 'email' | 'webPush' | 'mobilePush'>;
 }
 
 const humanize = (str) =>

--- a/src/components/UserPreferencesPanel/PreferencesCategories.tsx
+++ b/src/components/UserPreferencesPanel/PreferencesCategories.tsx
@@ -11,7 +11,7 @@ function channelToTitle(channel) {
     email: 'EMAIL',
     webPush: 'WEB PUSH',
     mobilePush: 'MOBILE PUSH',
-  }[channel] || 'IN-APP';
+  }[channel] || channel;
 }
 
 function getChannelsFromPreferences(preferences): string[] | undefined {
@@ -55,7 +55,7 @@ export default function PreferencesCategories() {
         css={css`
           display: grid;
           gap: 1rem;
-          grid-template-columns: 2fr ${' 1fr'.repeat(channels.length)};
+          grid-template-columns: 2fr ${' 1fr'.repeat(channels.length).trim()};
         `}
       >
         <div />

--- a/src/components/UserPreferencesPanel/PreferencesCategories.tsx
+++ b/src/components/UserPreferencesPanel/PreferencesCategories.tsx
@@ -5,6 +5,26 @@ import { useEffect } from 'react';
 
 import CategoryPreferences from './CategoryPreferences';
 
+function channelToTitle(channel) {
+  return {
+    inApp: 'IN-APP',
+    email: 'EMAIL',
+    webPush: 'WEB PUSH',
+    mobilePush: 'MOBILE PUSH',
+  }[channel] || 'IN-APP';
+}
+
+function getChannelsFromPreferences(preferences): string[] | undefined {
+  const channelPrefs: object[] = Object.values(preferences.categories);
+  if (channelPrefs.length > 0) {
+    const combinedChannels: object = channelPrefs.reduce((channels: object, otherChannels: object) => {
+      return { ...channels, ...otherChannels };
+    });
+    return Object.keys(combinedChannels);
+  }
+  return undefined;
+}
+
 export default function PreferencesCategories() {
   const preferences = useNotificationPreferences();
 
@@ -20,6 +40,8 @@ export default function PreferencesCategories() {
     }
   }, [preferences]);
 
+  let channels = getChannelsFromPreferences(preferences) || ['inapp', 'email', 'web-push'];
+
   return (
     <div
       css={css`
@@ -33,15 +55,15 @@ export default function PreferencesCategories() {
         css={css`
           display: grid;
           gap: 1rem;
-          grid-template-columns: 2fr 1fr 1fr 1fr;
+          grid-template-columns: 2fr ${' 1fr'.repeat(channels.length)};
         `}
       >
         <div />
-        <div css={headerStyle}>In-app</div>
-        <div css={headerStyle}>Email</div>
-        <div css={headerStyle}>Web push</div>
+        {channels.map((channel) =>(
+          <div key={channel} css={headerStyle}>{channelToTitle(channel)}</div>
+        ))}
         {Object.keys(preferences.categories).map((categoryKey) => (
-          <CategoryPreferences key={categoryKey} category={categoryKey} />
+          <CategoryPreferences key={categoryKey} category={categoryKey} channels={channels} />
         ))}
       </div>
     </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export { default as NotificationContent } from './components/NotificationContent
 export { default as NotificationInbox } from './components/NotificationInbox';
 export { default as NotificationList } from './components/NotificationList';
 export { default as NotificationState } from './components/NotificationState';
+export { default as NotificationPreferences } from './components/UserPreferencesPanel/PreferencesCategories';
 export type { PopoverPlacement } from './components/Popover';
 export { default as Popover } from './components/Popover';
 export { default as PushNotificationsSubscriber } from './components/PushNotificationsSubscriber';


### PR DESCRIPTION
- Expose `NotificationPreferences`. This allows users to embed notification preferences in another page.
- Only show enabled channels in `NotificationPreferences`. The component now looks to see which channels are enabled and only displays preferences for those channels. This should prevent customers from being confused about which channels are available to them. It also adds support for the Mobile Push channel.