### PR TITLE
feat: re-export eventAggregator from @magicbell/react-headless

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.4.1",
-    "@magicbell/react-headless": "^2.5.1",
+    "@magicbell/react-headless": "^2.6.0",
     "@tippyjs/react": "^4.2.4",
     "ably": "^1.2.14",
     "axios": "^0.24.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export { defaultTheme as defaultMagicBellTheme } from './context/Theme';
 export { darken, toRGBA } from './lib/color';
 export {
   clientSettings,
+  eventAggregator,
   INotification,
   INotificationsStoresCollection,
   INotificationStore,

--- a/tests/src/components/MagicBell/MagicBell.spec.tsx
+++ b/tests/src/components/MagicBell/MagicBell.spec.tsx
@@ -1,4 +1,4 @@
-import { pushEventAggregator } from '@magicbell/react-headless';
+import { eventAggregator } from '@magicbell/react-headless';
 import { render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 // import { renderWithProviders as render } from '../../../__utils__/render';
 import userEvent from '@testing-library/user-event';
@@ -211,7 +211,7 @@ test('calls the onNewNotification callback when a new notification is received',
   );
 
   const notification = NotificationFactory.build();
-  pushEventAggregator.emit('notifications.new', notification);
+  eventAggregator.emit('notifications.new', { data: notification, source: 'remote' });
 
   expect(onNewNotification).toHaveBeenCalledTimes(1);
   expect(onNewNotification).toHaveBeenCalledWith(notification);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1597,10 +1597,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@magicbell/react-headless@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@magicbell/react-headless/-/react-headless-2.5.1.tgz#8df82c485d6e943a9e28be892a76f878ae8c278c"
-  integrity sha512-Q8Ugpp+/+no+sIWe9hoLwx3TAY9PFdP9yX/dEgfu2HU5xZJ8jnq6OtHht3VV0qS5Oo68mUzTpPOBZa6O5cGlaA==
+"@magicbell/react-headless@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@magicbell/react-headless/-/react-headless-2.6.0.tgz#7cb41a6987be995cbe3fbb15a35a8827130cc1e5"
+  integrity sha512-l3O5uqEeoFxm1Ip+g1BmFk7kbk/jgiAyEVy/BfTvGIHsMVu24lUl6oidaKGBOplwFglsGPoD5lLTntHpJ1r9zQ==
   dependencies:
     ably "^1.2.14"
     axios "^0.24.0"
@@ -1608,7 +1608,7 @@
     humps "^2.0.1"
     immer "^9.0.6"
     mitt "^3.0.0"
-    ramda "^0.27.1"
+    ramda "^0.27.2"
     tslib "^2.3.1"
     zustand "^3.6.4"
 


### PR DESCRIPTION
Re-export the emitter added by https://github.com/magicbell-io/react-headless/pull/10