### PR TITLE
chore: make userExternalId and userEmail mutually exclusive

### DIFF
--- a/src/components/MagicBell/MagicBell.tsx
+++ b/src/components/MagicBell/MagicBell.tsx
@@ -16,10 +16,8 @@ type StoreConfig = {
   defaults?: Partial<Omit<INotificationStore, 'context'>>;
 };
 
-export interface Props {
+export type Props ={
   apiKey?: string;
-  userEmail?: string;
-  userExternalId?: string;
   userKey?: string;
   children: (params: {
     launcherRef: React.RefObject<Element>;
@@ -40,7 +38,11 @@ export interface Props {
   onNewNotification?: (notification: IRemoteNotification) => void;
   onToggle?: (isOpen: boolean) => void;
   bellCounter?: 'unread' | 'unseen';
-}
+} & (
+  // the props can either have the externalId **OR** the email of the user
+  { userExternalId?: string; } |
+  { userEmail?: string; }
+  )
 
 /**
  * Magicbell root component. Use this one in your application.

--- a/src/components/MagicBellProvider/MagicBellProvider.tsx
+++ b/src/components/MagicBellProvider/MagicBellProvider.tsx
@@ -10,10 +10,8 @@ import { TranslationsProvider } from '../../context/TranslationsContext';
 import { CustomLocale, useLocale } from '../../lib/i18n';
 import { DeepPartial } from '../../lib/types';
 
-export interface OptionalProps {
+export type OptionalProps = {
   userEmail?: string;
-  userExternalId?: string;
-  userKey?: string;
   children: React.ReactElement | React.ReactElement[];
   theme?: DeepPartial<IMagicBellTheme>;
   stores?;
@@ -23,11 +21,15 @@ export interface OptionalProps {
   }>;
   serverURL?: string;
   disableRealtime?: boolean;
-}
+} & (
+  // the props can either have the externalId **OR** the email of the user
+  { userExternalId?: string; } |
+  { userEmail?: string; }
+  )
 
-export interface Props extends OptionalProps {
+export type Props  = {
   apiKey: string;
-}
+} & OptionalProps
 
 /**
  * Provider component for Magicbell.


### PR DESCRIPTION
Right now the `MagicBell` and `MagicBellProvider` components have the `userExternalId` and `userEmail` as they should not be used together. This PR makes them mutually exclusive using typescript intersections.

I was also wondering whether one of the props should be required as it doesn't really make sense to use MagicBell without one of those props imo 