### PR TITLE
fix: don't invoke click handler when clicking embedded links

### DIFF
--- a/src/components/ClickableNotification/ClickableNotification.tsx
+++ b/src/components/ClickableNotification/ClickableNotification.tsx
@@ -26,10 +26,15 @@ export interface Props {
 export default function ClickableNotification({ notification: rawNotification, onClick }: Props) {
   const notification = useNotification(rawNotification);
 
-  const handleClick = () => {
+  const handleClick = (event) => {
     notification.markAsRead();
 
+    // As the notification is wrapped in a <button>, we don't want to invoke the action url when the
+    // user clicks a link inside that notification. The link should take precedence.
+    const clickedLink = event.target.tagName === 'A' && event.target.getAttribute('href');
+
     if (onClick) onClick(notification);
+    else if (clickedLink) return;
     else openActionUrl(notification);
   };
 


### PR DESCRIPTION
When a notification has links in them, such as our onboarding notification, we don't want to execute both the `actionUrl` and the embedded link.

Thereby, I'm now preventing the `actionUrl` from being opened when the user clicks a link. I've chosen not to block the `onClick` handler, as the consumer can handle the logic themselves. Some might want to block that action as well, while others might still want to handle that click because it's connected to analytics or something like that.

![image](https://user-images.githubusercontent.com/1196524/156758569-1a4b2593-6725-48bc-9aaa-0347144f3e35.png)
