### PR TITLE
feat: use FloatingNotificationInbox as default Inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,20 @@ These are all the properties accepted by this component.
 
 This component expects a children function. This is how you render whatever you want to based on the state of the `MagicBell`.
 
-You can use the notification inbox from this package (see [`NotificationInbox`](#notificationinbox)):
+You can use the standard notification inbox:
+
+```javascript
+import React from 'react';
+import ReactDOM from 'react-dom';
+import MagicBell from '@magicbell/magicbell-react';
+
+ReactDOM.render(
+  <MagicBell apiKey={MAGICBELL_API_KEY} userEmail="john@example.com" />,
+  document.body,
+);
+```
+
+Or the standard inbox with basic customizations (see [`NotificationInbox`](#notificationinbox)):
 
 ```javascript
 import React from 'react';
@@ -102,7 +115,7 @@ ReactDOM.render(
 );
 ```
 
-or use your own:
+Or use your own:
 
 <!-- prettier-ignore -->
 ```javascript

--- a/src/components/MagicBell/MagicBell.tsx
+++ b/src/components/MagicBell/MagicBell.tsx
@@ -8,6 +8,7 @@ import { IMagicBellTheme } from '../../context/Theme';
 import { CustomLocale } from '../../lib/i18n';
 import { DeepPartial } from '../../lib/types';
 import Bell from '../Bell';
+import FloatingNotificationInbox from '../FloatingNotificationInbox';
 import MagicBellChildrenWrapper from '../MagicBellProvider/MagicBellChildrenWrapper';
 
 type StoreConfig = {
@@ -21,7 +22,7 @@ export interface Props {
   userEmail?: string;
   userExternalId?: string;
   userKey?: string;
-  children: (params: {
+  children?: (params: {
     launcherRef: React.RefObject<Element>;
     isOpen: boolean;
     toggle: () => void;
@@ -41,6 +42,8 @@ export interface Props {
   onToggle?: (isOpen: boolean) => void;
   bellCounter?: 'unread' | 'unseen';
 }
+
+const defaultInbox = (props) => <FloatingNotificationInbox height={500} {...props} />;
 
 /**
  * Magicbell root component. Use this one in your application.
@@ -69,7 +72,7 @@ export interface Props {
  * </MagicBell>
  */
 export default function MagicBell({
-  children,
+  children = defaultInbox,
   BellIcon,
   Badge,
   defaultIsOpen = false,

--- a/stories/MagicBell.stories.tsx
+++ b/stories/MagicBell.stories.tsx
@@ -8,6 +8,12 @@ import { MagicBellProps } from '../src/components/MagicBell';
 import { IMagicBellTheme } from '../src/context/Theme';
 import { DeepPartial } from '../src/lib/types';
 
+const user = {
+  apiKey: 'df24a28e8921181f6c4220fc306ba76701592d21',
+  userEmail: 'josue@magicbell.io',
+  userKey: 'pvorWv0ff2MvYFNyadwOLmFzTZnT1LCFxzTELAULYT4=',
+};
+
 interface IStory extends MagicBellProps {
   onAllRead: () => void;
   onNotificationClick: (notification: INotification) => void;
@@ -40,17 +46,13 @@ const Template: Story<IStory> = ({ onAllRead, onNotificationClick, ...args }: IS
 
 export const Default = Template.bind({});
 Default.args = {
-  apiKey: 'df24a28e8921181f6c4220fc306ba76701592d21',
-  userEmail: 'josue@magicbell.io',
-  userKey: 'pvorWv0ff2MvYFNyadwOLmFzTZnT1LCFxzTELAULYT4=',
+  ...user,
   locale: 'en',
 };
 
 export const WithCustomIcon = Template.bind({});
 WithCustomIcon.args = {
-  apiKey: 'df24a28e8921181f6c4220fc306ba76701592d21',
-  userEmail: 'josue@magicbell.io',
-  userKey: 'pvorWv0ff2MvYFNyadwOLmFzTZnT1LCFxzTELAULYT4=',
+  ...user,
   BellIcon: (
     <svg viewBox="0 0 24 24">
       <path d="M10,21.75a2.087,2.087,0,0,0,4.005,0" />
@@ -62,9 +64,7 @@ WithCustomIcon.args = {
 
 export const WithCustomTheme = Template.bind({});
 WithCustomTheme.args = {
-  apiKey: 'df24a28e8921181f6c4220fc306ba76701592d21',
-  userEmail: 'josue@magicbell.io',
-  userKey: 'pvorWv0ff2MvYFNyadwOLmFzTZnT1LCFxzTELAULYT4=',
+  ...user,
   theme: {
     header: { backgroundColor: '#FAD776', textColor: '#161C2D' },
     footer: { backgroundColor: '#FAD776', textColor: '#161C2D' },
@@ -76,17 +76,13 @@ WithCustomTheme.args = {
 
 export const WithInboxOpen = Template.bind({});
 WithInboxOpen.args = {
-  apiKey: 'df24a28e8921181f6c4220fc306ba76701592d21',
-  userEmail: 'josue@magicbell.io',
-  userKey: 'pvorWv0ff2MvYFNyadwOLmFzTZnT1LCFxzTELAULYT4=',
+  ...user,
   defaultIsOpen: true,
 };
 
 export const WithCustomEmptyImage = Template.bind({});
 WithCustomEmptyImage.args = {
-  apiKey: 'df24a28e8921181f6c4220fc306ba76701592d21',
-  userEmail: 'josue@magicbell.io',
-  userKey: 'pvorWv0ff2MvYFNyadwOLmFzTZnT1LCFxzTELAULYT4=',
+  ...user,
   images: {
     emptyInboxUrl:
       'https://thumbs.dreamstime.com/b/inbox-box-cabinet-document-empty-project-blue-icon-abstract-cloud-background-148443579.jpg',
@@ -95,15 +91,13 @@ WithCustomEmptyImage.args = {
 
 export const WithUnreadCount = Template.bind({});
 WithUnreadCount.args = {
-  apiKey: 'df24a28e8921181f6c4220fc306ba76701592d21',
-  userEmail: 'josue@magicbell.io',
-  userKey: 'pvorWv0ff2MvYFNyadwOLmFzTZnT1LCFxzTELAULYT4=',
+  ...user,
   bellCounter: 'unread',
 };
 
 export const WithCustomBadge = Template.bind({});
 WithCustomBadge.args = {
-  ...Default.args,
+  ...user,
   bellCounter: 'unread',
   Badge: ({ count }) => (
     <div
@@ -125,3 +119,5 @@ WithCustomBadge.args = {
     </div>
   ),
 };
+
+export const Simple = () => <MagicBell {...user} />;

--- a/tests/src/components/MagicBell/MagicBell.spec.tsx
+++ b/tests/src/components/MagicBell/MagicBell.spec.tsx
@@ -49,7 +49,22 @@ afterEach(() => {
   server.shutdown();
 });
 
-test("renders the notification bell, but not it's children", async () => {
+test("renders the notification bell, but not it's default children", async () => {
+  render(<MagicBell apiKey={apiKey} userEmail={userEmail} userKey={userKey} />);
+
+  screen.getByRole('button', { name: 'Notifications' });
+  expect(screen.queryByRole('button', { name: /mark all read/i })).not.toBeInTheDocument();
+});
+
+test('clicking the bell opens the default inbox', async () => {
+  render(<MagicBell apiKey={apiKey} userEmail={userEmail} userKey={userKey} />);
+
+  const button = screen.getByRole('button');
+  userEvent.click(button);
+  await screen.findByRole('button', { name: /Mark All Read/i });
+});
+
+test("renders the notification bell, but not it's custom children", async () => {
   render(
     <MagicBell apiKey={apiKey} userEmail={userEmail} userKey={userKey}>
       {() => <div data-testid="children" />}
@@ -60,7 +75,7 @@ test("renders the notification bell, but not it's children", async () => {
   expect(screen.queryByTestId('children')).not.toBeInTheDocument();
 });
 
-test('clicking the bell opens the inbox', async () => {
+test('clicking the bell opens the custom inbox', async () => {
   render(
     <MagicBell apiKey={apiKey} userEmail={userEmail} userKey={userKey}>
       {() => <div data-testid="children" />}


### PR DESCRIPTION
I've set the FloatingNotificationInbox as the default value for the MagicBell children.

What this means is, the most basic implementation get's reduced from:

```tsx
<MagicBell apiKey={MAGICBELL_API_KEY} userEmail="john@example.com">
  {() => <FloatingNotificationInbox height={500} />}
</MagicBell>
```

to

```tsx
<MagicBell apiKey={MAGICBELL_API_KEY} userEmail="john@example.com" />
```