### PR TITLE
chore: export popperOptions type

### DIFF
--- a/src/components/FloatingNotificationInbox/FloatingInboxContainer.tsx
+++ b/src/components/FloatingNotificationInbox/FloatingInboxContainer.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 
 import { NotificationInboxProps } from '../NotificationInbox';
-import Popover, { PopoverPlacement } from '../Popover';
+import Popover, { PopoverPlacement, PopperOptions } from '../Popover';
 import Arrow from './Arrow';
 import StyledPopoverContainer from './StyledPopoverContainer';
 
@@ -12,7 +12,7 @@ export interface Props extends NotificationInboxProps {
   placement?: PopoverPlacement;
   width?: number;
   closeOnClickOutside?: boolean;
-  popperOptions?;
+  popperOptions?: PopperOptions;
   hideArrow?: boolean;
   layout?: string[];
   children: ReactNode | ReactNode[];

--- a/src/components/FloatingNotificationInbox/FloatingNotificationInbox.tsx
+++ b/src/components/FloatingNotificationInbox/FloatingNotificationInbox.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { openActionUrl } from '../ClickableNotification/eventHandlers';
 import NotificationInbox, { NotificationInboxProps } from '../NotificationInbox';
 import { NotificationListItem } from '../NotificationList/NotificationList';
-import { PopoverPlacement } from '../Popover';
+import { PopoverPlacement, PopperOptions } from '../Popover';
 import FloatingInboxContainer from './FloatingInboxContainer';
 
 export interface Props extends NotificationInboxProps {
@@ -14,7 +14,7 @@ export interface Props extends NotificationInboxProps {
   width?: number;
   closeOnClickOutside?: boolean;
   closeOnNotificationClick?: boolean;
-  popperOptions?;
+  popperOptions?: PopperOptions;
   hideArrow?: boolean;
   NotificationItem?: NotificationListItem;
   layout?: string[];

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,22 +1,10 @@
+import type { Options, Placement as PopoverPlacement } from '@popperjs/core';
 import Tippy from '@tippyjs/react/headless';
 import React from 'react';
 
-export type PopoverPlacement =
-  | 'auto'
-  | 'auto-start'
-  | 'auto-end'
-  | 'top'
-  | 'bottom'
-  | 'right'
-  | 'left'
-  | 'top-start'
-  | 'top-end'
-  | 'bottom-start'
-  | 'bottom-end'
-  | 'right-start'
-  | 'right-end'
-  | 'left-start'
-  | 'left-end';
+type PopperOptions = Partial<Options>;
+
+export { PopoverPlacement, PopperOptions };
 
 export interface PopoverProps {
   children: (attrs) => React.ReactNode;
@@ -27,7 +15,7 @@ export interface PopoverProps {
   offset?: { skidding: number; distance: number };
   onClickOutside?: () => void;
   placement?: PopoverPlacement;
-  popperOptions?;
+  popperOptions?: PopperOptions;
   zIndex?: number;
   trigger?: 'mouseenter focus' | 'click' | 'focusin' | 'mouseenter click' | 'manual';
 }

--- a/src/components/Popover/index.ts
+++ b/src/components/Popover/index.ts
@@ -1,3 +1,3 @@
 import Popover from './Popover';
-export type { PopoverPlacement, PopoverProps } from './Popover';
+export type { PopoverPlacement, PopoverProps, PopperOptions } from './Popover';
 export default Popover;


### PR DESCRIPTION
### Change
Resolves #15 - Expose popperOptions type

## Description
Importing `Options` type from `@popperjs/core` package which is peer dep used by [tippyjs](https://github.com/atomiks/tippyjs)
[tippyjs - popperOptions type](https://github.com/atomiks/tippyjs/blob/8f7b2df156ae39c4df23c481b77ab59fe7f08c44/src/types.ts#L96)
