### PR TITLE
fix: ensure that infinite scroll doesn't bind to window

### DIFF
--- a/src/components/NotificationList/NotificationList.tsx
+++ b/src/components/NotificationList/NotificationList.tsx
@@ -21,7 +21,6 @@ export interface NotificationListProps {
   ListItem?: (props: ListItemProps) => React.ReactElement;
   notifications: NotificationStore;
   queryParams?;
-  scrollableTarget?: React.ReactNode;
 }
 
 /**
@@ -38,9 +37,8 @@ export interface NotificationListProps {
 export default function NotificationList({
   notifications: store,
   onItemClick,
-  height,
+  height = 410,
   queryParams,
-  scrollableTarget,
   ListItem = ClickableNotification,
 }: NotificationListProps) {
   return (
@@ -50,7 +48,6 @@ export default function NotificationList({
       next={() => store.fetchNextPage(queryParams)}
       loader={<Loader />}
       height={height}
-      scrollableTarget={scrollableTarget}
     >
       {store.notifications.map((notification) => (
         <ListItem key={notification.id} notification={notification} onClick={onItemClick} />


### PR DESCRIPTION
This ensures that the `InfiniteScroll` component receives a height on initial render. It no longer supports the `scrollableTarget` prop to specify what element to bind to.

**Problem**:

On first render, both the `height` and `scrollableTarget` were `undefined`, which configures `InfiniteScroll` to bind to the window scroll event instead. That's not what we want.

**Solution**

One solution would be to add a `if (!scrollableTarget) return null` statement, but that would break usages where one uses the `NotificationList` component in a way that they don't provide the optional `scrollableTarget`.

This solution simply sets a default height, which is directly corrected by our parent component (`NotificationInboxContent`). If one uses the `NotificationList` component directly, that will remain working.

The only downside I can think of is that people no longer can specify a `scrollableTarget` if they wanted to. I see that as a more advanced use case than those that want to specify a height.

By specifying a default height, we also directly fix the problem that the inbox grows larger than the screen, when one doesn't provide a height on the root component.