### PR TITLE
fix: ensure that older notifications are loaded when scrolling down

### DIFF
--- a/src/components/NotificationInbox/NotificationInboxContent.tsx
+++ b/src/components/NotificationInbox/NotificationInboxContent.tsx
@@ -4,7 +4,6 @@ import { NotificationStore } from '@magicbell/react-headless/dist/hooks/useNotif
 import INotification from '@magicbell/react-headless/dist/types/INotification';
 import { useState } from 'react';
 
-import { useHeight } from '../../lib/window';
 import NotificationList from '../NotificationList';
 import { NotificationListItem } from '../NotificationList/NotificationList';
 
@@ -33,17 +32,18 @@ export default function NotificationInboxContent({
 }: NotificationInboxContentProps) {
   // we use a refSetter so that the height observer is reattached on a ref change
   const [contentRef, setContentRef] = useState<HTMLDivElement | null>(null);
-  const contentHeight = useHeight(contentRef, height);
 
   return (
-    <div ref={setContentRef} css={{ width: '100%', height: height ?? '100%' }}>
-      <NotificationList
-        height={contentHeight}
-        notifications={store}
-        onItemClick={onNotificationClick}
-        queryParams={store.context}
-        ListItem={NotificationItem}
-      />
+    <div ref={setContentRef} css={{ width: '100%', height: height ?? '100%', overflow: 'auto' }}>
+      {contentRef ? (
+        <NotificationList
+          scrollableTarget={contentRef}
+          notifications={store}
+          onItemClick={onNotificationClick}
+          queryParams={store.context}
+          ListItem={NotificationItem}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
This ensures that the `InfiniteScroll` component only renders when the `scroll parent` is known.

**Problem**:

On the first render, both the `height` and `scrollableTarget` were `undefined`, which configures `InfiniteScroll` to bind to the window scroll event instead. That's not what we want.

**Solution**

Now `NotificationList` only renders after the `contentRef` has been populated. No `contentRef`, no render, and no way for `InfiniteScroll` to attach to the `document.body`.

This pull replaces #176, as this solution is fully backward compatible without loss of options.