### PR TITLE
test: ensure that test doesn't depend on number of requests made

### DIFF
--- a/tests/src/components/MagicBell/MagicBell.spec.tsx
+++ b/tests/src/components/MagicBell/MagicBell.spec.tsx
@@ -180,36 +180,54 @@ test('calls the onToggle callback when the button is clicked', async () => {
   expect(onToggle).toHaveBeenCalledTimes(1);
 });
 
-test('sets the headers for fetching from the API', () => {
+test('sets the headers for fetching from the API', async () => {
+  const serverSpy = jest.fn();
+  server.get('/notifications', (_, req) => {
+    serverSpy(req.requestHeaders);
+    return new Response(200, {}, {});
+  });
+
   render(
     <MagicBell apiKey={apiKey} userEmail={userEmail} userKey={userKey}>
-      {() => <div data-testid="children" />}
+      {() => <div />}
     </MagicBell>,
   );
 
-  const requests = server.pretender.handledRequests;
-  expect(requests[0].requestHeaders).toMatchObject({
-    'X-MAGICBELL-API-KEY': apiKey,
-    'X-MAGICBELL-USER-EMAIL': userEmail,
-    'X-MAGICBELL-USER-HMAC': userKey,
-  });
+  await waitFor(() => expect(serverSpy).toHaveBeenCalled());
+
+  expect(serverSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      'X-MAGICBELL-API-KEY': apiKey,
+      'X-MAGICBELL-USER-EMAIL': userEmail,
+      'X-MAGICBELL-USER-HMAC': userKey,
+    }),
+  );
 });
 
 test('sets the external id header for fetching from the API', async () => {
   const userExternalId = faker.random.alphaNumeric(15);
 
+  const serverSpy = jest.fn();
+  server.get('/notifications', (_, req) => {
+    serverSpy(req.requestHeaders);
+    return new Response(200, {}, {});
+  });
+
   render(
     <MagicBell apiKey={apiKey} userExternalId={userExternalId} userKey={userKey}>
-      {() => <div data-testid="children" />}
+      {() => <div />}
     </MagicBell>,
   );
 
-  const requests = server.pretender.handledRequests;
-  expect(requests[0].requestHeaders).toMatchObject({
-    'X-MAGICBELL-API-KEY': apiKey,
-    'X-MAGICBELL-USER-EXTERNAL-ID': userExternalId,
-    'X-MAGICBELL-USER-HMAC': userKey,
-  });
+  await waitFor(() => expect(serverSpy).toHaveBeenCalled());
+
+  expect(serverSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      'X-MAGICBELL-API-KEY': apiKey,
+      'X-MAGICBELL-USER-EXTERNAL-ID': userExternalId,
+      'X-MAGICBELL-USER-HMAC': userKey,
+    }),
+  );
 });
 
 test('calls the onNewNotification callback when a new notification is received', () => {

--- a/tests/src/components/MagicBell/MagicBell.spec.tsx
+++ b/tests/src/components/MagicBell/MagicBell.spec.tsx
@@ -15,7 +15,7 @@ const apiKey = faker.random.alphaNumeric(10);
 const userEmail = faker.internet.email();
 const userKey = faker.random.alphaNumeric(10);
 
-let server;
+let server: Server;
 
 beforeEach(() => {
   server = new Server({
@@ -24,7 +24,7 @@ beforeEach(() => {
     trackRequests: true,
     timing: 50,
   });
-  server.get('/notifications', {
+  server.get('/notifications', () => ({
     total: 5,
     current_page: 1,
     per_page: 15,
@@ -33,16 +33,17 @@ beforeEach(() => {
     unseen_count: 0,
     unread_count: 4,
     notifications: NotificationFactory.buildList(5),
-  });
-  server.get('/config', sampleConfig);
-  server.get('/notification_preferences', {
+  }));
+
+  server.get('/config', () => sampleConfig);
+  server.get('/notification_preferences', () => ({
     notification_preferences: {
       categories: {
         comments: { email: false },
       },
     },
-  });
-  server.post('/notifications/seen', new Response(204, {}, ''));
+  }));
+  server.post('/notifications/seen', () => new Response(204, {}, ''));
 });
 
 afterEach(() => {


### PR DESCRIPTION
This ensures that the tests that check for request headers do not depend on the number of requests made, or request order.