### PR TITLE
fix: ensure notification time is aligned on right

### DIFF
--- a/src/components/ClickableNotification/ClickableNotification.tsx
+++ b/src/components/ClickableNotification/ClickableNotification.tsx
@@ -41,6 +41,7 @@ export default function ClickableNotification({ notification: rawNotification, o
     padding: 0 5px !important;
     flex-direction: column;
     align-items: flex-end;
+    margin-left: auto !important;
   `;
 
   const content = css`


### PR DESCRIPTION
This ensures that the notification time & menu is aligned on the right, even if the notification content is only a few words, and thereby not long enough to push the width to 100%.

![image](https://user-images.githubusercontent.com/1196524/178476455-4aba0cca-7935-408c-be2b-b10768c24f40.png)
