### PR TITLE
fix: don't mark as read when clicked inside notification menu

### DIFF
--- a/src/components/ClickableNotification/ClickableNotification.tsx
+++ b/src/components/ClickableNotification/ClickableNotification.tsx
@@ -27,7 +27,9 @@ export interface Props {
 export default function ClickableNotification({ notification: rawNotification, onClick }: Props) {
   const notification = useNotification(rawNotification);
 
-  const handleMarkAsRead = () => {
+  const handleMarkAsRead = (event) => {
+    // don't mark as read when user clicks inside the menu
+    if (event.isDefaultPrevented()) return;
     notification.markAsRead();
   };
 

--- a/src/components/NotificationContextMenu/NotificationContextMenu.tsx
+++ b/src/components/NotificationContextMenu/NotificationContextMenu.tsx
@@ -30,6 +30,7 @@ export default function NotificationContextMenu({ notification }: Props) {
 
   return (
     <div
+      onClick={(e) => e.preventDefault()}
       css={css`
         background: ${containerTheme.backgroundColor} !important;
         border-radius: 4px !important;


### PR DESCRIPTION
Fixes a bug where users can't mark notifications as unread because the click propagates to the notification, which is responsible for "marking as read".